### PR TITLE
Add warning for strings prefixed with L.

### DIFF
--- a/logger.cc
+++ b/logger.cc
@@ -293,4 +293,6 @@ const char *Logger::warning_messages[] = {
    "Condition is always true.",
    "Condition is always false.",
    "Multiple handlers for event `%s' - only the last will execute.",
+   "Prefixing a string with L will cause a double quote (\")\n"
+     "to be inserted at the beginning of the string.",
 };

--- a/logger.hh
+++ b/logger.hh
@@ -85,6 +85,7 @@ enum ErrorCode {
     W_CONDITION_ALWAYS_TRUE,
     W_CONDITION_ALWAYS_FALSE,
     W_MULTIPLE_EVENT_HANDLERS,
+    W_L_STRING,
     W_LAST,
     
     

--- a/lslmini.l
+++ b/lslmini.l
@@ -97,7 +97,12 @@ FS			(f|F)
 [-]?{D}*"."{D}+({E})?{FS}?	{ yylval->fval = (F32)atof(yytext); return(FP_CONSTANT); }
 [-]?{D}+"."{D}*({E})?{FS}?	{ yylval->fval = (F32)atof(yytext); return(FP_CONSTANT); }
 
-L?\"(\\.|[^\\"])*\"	{ yylval->sval = parse_string(yytext); return(STRING_CONSTANT); }
+L\"(\\.|[^\\"])*\"	{
+    yylval->sval = parse_string(yytext);
+    ERROR( yylloc, W_L_STRING );
+    return(STRING_CONSTANT);
+}
+\"(\\.|[^\\"])*\"	{ yylval->sval = parse_string(yytext); return(STRING_CONSTANT); }
 
 "++"				{ return(INC_OP); }
 "--"				{ return(DEC_OP); }


### PR DESCRIPTION
(New feature) Due to a bug in parse_string(), the first quote goes into the string if there is an L prefix in it:

```
default
{
    state_entry()
    {
        llSay(0, L"Hello, avatar!");
    }
}
```

The above displays: `"Hello, avatar!`.

This patch adds a warning about it.
