### PR TITLE
Allow // comments in builtins.txt; simplify Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,10 +88,9 @@ $(OBJS): lslmini.hh
 
 builtins_txt.cc: builtins.txt
 	echo "char *builtins_txt[] = {" > builtins_txt.cc
-	cat builtins.txt | \
-		sed "s/\"/\\\\\\\"/g" | \
-		sed "s/^/\"/g" | \
-		sed "s/$$/\",/g" >> builtins_txt.cc
+	sed -e '/^\/\//d; s/"/\\\"/g; s/^/"/; s/$$/",/' \
+		builtins.txt >> builtins_txt.cc || \
+			{ rm -f builtins_txt.cc ; false ; }
 	echo "(char*)0 };" >> builtins_txt.cc
 
 lex.yy.o: lex.yy.c lslmini.tab.h llconstants.hh


### PR DESCRIPTION
Removes // lines at the very start of the line during sed processing, to allow for comments.

Also compact the sed lines into one, using single instead of double quotes, and remove builtins_txt.cc in case sed fails, so that a subsequent 'make' invocation doesn't work on a bogus or incomplete builtins_txt.cc file.
